### PR TITLE
create outdir

### DIFF
--- a/grphin.py
+++ b/grphin.py
@@ -9,6 +9,7 @@ import networkx as nx
 import csv
 import numpy as np
 from collections import defaultdict
+import os
 
 
 def count_two_node_graphlet(G, output_dir):
@@ -44,6 +45,7 @@ def generate_two_node_output_files(
     two_node_orbit_dict,
     output_dir,
 ):
+    os.makedirs(output_dir, exist_ok=True)
     with open(f"{output_dir}/two_node_graphlet_counts.csv", "w") as f:
         for key in two_node_graphlet_id:
             f.write(f"G_{two_node_graphlet_id[key]}, {two_node_graphlet_count[key]}\n")


### PR DESCRIPTION
creates outdir if it doesn't exist; current error points to missing file rather than missing outdir; tested with: 
```
python3 grphin/grphin.py -u grphin/data/oxidative_stress/txid224308/stress_ppi.csv -d grphin/data/oxidative_stress/txid224308/stress_reg.csv -o out_dir_20250707
```
